### PR TITLE
Added the GMapEventOnce class (removes the listener after the first event)

### DIFF
--- a/lib/GMapEventOnce.class.php
+++ b/lib/GMapEventOnce.class.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * 
+ * A googleMap Event (once)
+ * @author Nicolas Martin
+ * 
+ */
+class GMapEventOnce extends GMapEvent
+{
+  
+  /**
+   * returns the javascript code for attaching a Google event only once to a javascript_object
+   *
+   * @param string $js_object_name
+   * @return string
+   * @author Nicolas Martin
+   */
+  public function getEventJs($js_object_name)
+  {
+    
+    return 'google.maps.event.addListenerOnce('.$js_object_name.', "'.$this->getTrigger().'", '.$this->getFunction().');';
+  }
+  
+   /**
+   * returns the javascript code for attaching a dom event once to a javascript_object
+   *
+   * @param string $js_object_name
+   * @return string
+   * @author Nicolas Martin
+   */
+  public function getDomEventJs($js_object_name)
+  {
+    
+    return 'google.maps.event.addDomListenerOnce('.$js_object_name.', "'.$this->getTrigger().'", '.$this->getFunction().');';
+  }
+  
+}
+


### PR DESCRIPTION
Hello,

This new class allows the event to be triggered just once.

It uses the 'addListenerOnce' and 'addDomListenerOnce' methods (cf. http://code.google.com/apis/maps/documentation/javascript/reference.html#event)
