### PR TITLE
fix Google API Calls

### DIFF
--- a/modules/phpOnlySamples/02_event-simple.php
+++ b/modules/phpOnlySamples/02_event-simple.php
@@ -21,7 +21,7 @@ $gMap->setHeight('500');
 $gMap->setWidth('100%');
 
 $marker = new GMapMarker(-25.363882, 131.044922, array('title'=>'"Hello World!"'));
-$marker->addEvent(new GMapEvent('click', 'map.set_zoom(8);'));
+$marker->addEvent(new GMapEvent('click', 'map.setZoom(8);'));
 $gMap->addMarker($marker);
 
 $gMap->addEvent(new GMapEvent('zoom_changed', 'setTimeout(moveToDarwin, 1500);'));
@@ -41,7 +41,7 @@ $gMap->addEvent(new GMapEvent('zoom_changed', 'setTimeout(moveToDarwin, 1500);')
     <script type="text/javascript">
     function moveToDarwin() {
       var darwin = new google.maps.LatLng(-12.461334, 130.841904);
-      map.set_center(darwin);
+      map.setCenter(darwin);
     }
   </script>
   </head>

--- a/modules/phpOnlySamples/03_event-closure.php
+++ b/modules/phpOnlySamples/03_event-closure.php
@@ -21,7 +21,7 @@ $gMap->setHeight('500');
 $gMap->setWidth('100%');
 
 $marker = new GMapMarker(-25.363882, 131.044922, array('title'=>'"Hello World!"'));
-$marker->addEvent(new GMapEvent('click', 'map.set_zoom(8);'));
+$marker->addEvent(new GMapEvent('click', 'map.setZoom(8);'));
 $gMap->addMarker($marker);
 
 $gMap->addEvent(new GMapEvent('zoom_changed', 'setTimeout(moveToDarwin, 1500);'));
@@ -41,7 +41,7 @@ $gMap->addEvent(new GMapEvent('zoom_changed', 'setTimeout(moveToDarwin, 1500);')
     <script type="text/javascript">
     function moveToDarwin() {
       var darwin = new google.maps.LatLng(-12.461334, 130.841904);
-      map.set_center(darwin);
+      map.setCenter(darwin);
     }
   </script>
   </head>

--- a/web/js/sfEasyGMapPlugin.js
+++ b/web/js/sfEasyGMapPlugin.js
@@ -50,9 +50,9 @@ var set_location = function(response, status)
   marker.gps_precision = zoom;
   //console.log('position settée ' + marker.google_position);
   
-  marker.set_position(point);
-  map.set_zoom(zoom);
-  map.set_center(point);
+  marker.setPosition(point);
+  map.setZoom(zoom);
+  map.setCenter(point);
 }
 
 var geocode_and_show = function (address)

--- a/web/js/sfEasyGMapPlugin.sample.js
+++ b/web/js/sfEasyGMapPlugin.sample.js
@@ -2,8 +2,8 @@
 var moveToMarker = function ()
 {
   var darwin = new google.maps.LatLng(-12.461334, 130.841904);
-  map.set_zoom(13);
-  map.set_center(darwin);
+  map.setZoom(13);
+  map.setCenter(darwin);
   
   gmapSample_AddConsoleLine("You just click on Darwin's marker !");
 }


### PR DESCRIPTION
I know this is a really old plugin and we're all supposed to be using SF2... but the Google API moved from get_xxx() to getXXX().

See http://groups.google.com/group/google-maps-js-api-v3/browse_thread/thread/95154fc3f3f0d026/87b7644581eabab0
